### PR TITLE
fix(feed): block pre-lock pick disclosure in league feeds

### DIFF
--- a/apps/backend/convex/feed.test.ts
+++ b/apps/backend/convex/feed.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { Id } from './_generated/dataModel';
-import { buildFilteredFeedPage, getPersonalizedFeedPageData } from './feed';
+import {
+  buildFilteredFeedPage,
+  getPersonalizedFeedPageData,
+  getSessionLockAt,
+  isSessionLockedAt,
+} from './feed';
 
 const MAX_FEED_SIZE = 40;
 const FEED_SCAN_BATCH_SIZE = MAX_FEED_SIZE;
@@ -432,5 +437,28 @@ describe('getPersonalizedFeedPageData', () => {
         },
       ],
     });
+  });
+});
+
+describe('session lock helpers', () => {
+  const race = {
+    qualiLockAt: 1000,
+    sprintQualiLockAt: 2000,
+    sprintLockAt: 3000,
+    predictionLockAt: 4000,
+  };
+
+  it('maps session types to the correct lock timestamps', () => {
+    expect(getSessionLockAt(race, 'quali')).toBe(1000);
+    expect(getSessionLockAt(race, 'sprint_quali')).toBe(2000);
+    expect(getSessionLockAt(race, 'sprint')).toBe(3000);
+    expect(getSessionLockAt(race, 'race')).toBe(4000);
+  });
+
+  it('treats sessions as locked only at or after lock time', () => {
+    expect(isSessionLockedAt(race, 'quali', 999)).toBe(false);
+    expect(isSessionLockedAt(race, 'quali', 1000)).toBe(true);
+    expect(isSessionLockedAt(race, 'race', 3999)).toBe(false);
+    expect(isSessionLockedAt(race, 'race', 4000)).toBe(true);
   });
 });

--- a/apps/backend/convex/feed.ts
+++ b/apps/backend/convex/feed.ts
@@ -20,6 +20,45 @@ type SessionType = Doc<'results'>['sessionType'];
 
 type DbCtx = { db: DatabaseReader };
 
+export function getSessionLockAt(
+  race: Pick<
+    Doc<'races'>,
+    | 'qualiLockAt'
+    | 'sprintQualiLockAt'
+    | 'sprintLockAt'
+    | 'predictionLockAt'
+  >,
+  sessionType: SessionType,
+): number | undefined {
+  switch (sessionType) {
+    case 'quali':
+      return race.qualiLockAt;
+    case 'sprint_quali':
+      return race.sprintQualiLockAt;
+    case 'sprint':
+      return race.sprintLockAt;
+    case 'race':
+      return race.predictionLockAt;
+    default:
+      return undefined;
+  }
+}
+
+export function isSessionLockedAt(
+  race: Pick<
+    Doc<'races'>,
+    | 'qualiLockAt'
+    | 'sprintQualiLockAt'
+    | 'sprintLockAt'
+    | 'predictionLockAt'
+  >,
+  sessionType: SessionType,
+  now: number,
+): boolean {
+  const lockAt = getSessionLockAt(race, sessionType);
+  return lockAt != null && now >= lockAt;
+}
+
 async function getPersonalizedFeedUserIds(ctx: DbCtx, viewerId: Id<'users'>) {
   const userIds = new Set<Id<'users'>>();
   userIds.add(viewerId);
@@ -687,6 +726,11 @@ async function enrichScoreEvent(
   const raceId = event.raceId;
 
   if (event.type === 'session_locked') {
+    const race = await ctx.db.get(raceId);
+    if (!race || !isSessionLockedAt(race, sessionType, Date.now())) {
+      return { picks: undefined, h2hScore: null };
+    }
+
     // Results not yet published — load picks from predictions table (unscored)
     const prediction = await ctx.db
       .query('predictions')
@@ -958,7 +1002,17 @@ export const getPersonalizedFeed = query({
 export const getLeagueFeed = query({
   args: { leagueId: v.id('leagues'), paginationCursor: v.optional(v.string()) },
   handler: async (ctx, { leagueId, paginationCursor }) => {
-    const viewer = await getViewer(ctx);
+    const viewer = requireViewer(await getViewer(ctx));
+
+    const membership = await ctx.db
+      .query('leagueMembers')
+      .withIndex('by_league_user', (q) =>
+        q.eq('leagueId', leagueId).eq('userId', viewer._id),
+      )
+      .unique();
+    if (!membership) {
+      throw new Error('Not a member of this league');
+    }
 
     const memberUserIds = await getLeagueFeedUserIds(ctx, leagueId);
     const { page, hasMore, nextCursor } = await buildFilteredFeedPage(
@@ -1164,6 +1218,12 @@ export const backfillSessionLockFeedEvents = internalMutation({
     }
 
     const now = Date.now();
+    if (!isSessionLockedAt(race, args.sessionType, now)) {
+      throw new Error(
+        `Cannot backfill session_locked feed events before ${args.sessionType} lock`,
+      );
+    }
+
     let created = 0;
 
     for await (const prediction of ctx.db


### PR DESCRIPTION
- Only enrich session_locked feed events after the session lock time
- Require league membership and authentication for getLeagueFeed
- Reject session lock backfill when the session is not yet locked
- Add unit tests for session lock timestamp helpers