### PR TITLE
fix(security): gate H2H feed picks behind session lock

### DIFF
--- a/apps/backend/convex/h2h.ts
+++ b/apps/backend/convex/h2h.ts
@@ -24,6 +24,19 @@ function getWeekendSessions(hasSprint: boolean): Array<SessionType> {
     : ['quali', 'race'];
 }
 
+/** Whether a viewer may read another user's H2H picks for a session (owners always can). */
+export function canViewH2HPicksForSession(params: {
+  isOwner: boolean;
+  lockTime: number | undefined;
+  now: number;
+}): boolean {
+  if (params.isOwner) {
+    return true;
+  }
+  const { lockTime, now } = params;
+  return lockTime != null && now >= lockTime;
+}
+
 export function resolveH2HSessionsToUpdate(params: {
   hasSprint: boolean;
   requestedSessionType?: SessionType;
@@ -624,10 +637,8 @@ export const getUserH2HDetailedPicks = query({
     };
 
     for (const [sessionType, sessionPredictions] of predictionsBySession) {
-      // Visibility check: non-owner can't see picks before lock
       const lockTime = lockTimes[sessionType];
-      if (!isOwner && (!lockTime || now < lockTime)) {
-        // Hidden — leave as null
+      if (!canViewH2HPicksForSession({ isOwner, lockTime, now })) {
         continue;
       }
 
@@ -676,6 +687,25 @@ export const getH2HPicksForFeedItem = query({
     sessionType: sessionTypeValidator,
   },
   handler: async (ctx, args) => {
+    const viewer = await getViewer(ctx);
+    const isOwner = viewer?._id === args.userId;
+
+    const race = await ctx.db.get(args.raceId);
+    if (!race) {
+      return null;
+    }
+
+    const lockTimes: Record<SessionType, number | undefined> = {
+      quali: race.qualiLockAt,
+      sprint_quali: race.sprintQualiLockAt,
+      sprint: race.sprintLockAt,
+      race: race.predictionLockAt,
+    };
+    const lockTime = lockTimes[args.sessionType];
+    if (!canViewH2HPicksForSession({ isOwner, lockTime, now: Date.now() })) {
+      return null;
+    }
+
     const preds = await ctx.db
       .query('h2hPredictions')
       .withIndex('by_user_race_session', (q) =>

--- a/apps/backend/convex/h2h.visibility.test.ts
+++ b/apps/backend/convex/h2h.visibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { canViewH2HPicksForSession } from './h2h';
+
+describe('canViewH2HPicksForSession', () => {
+  const lockTime = 1_000_000;
+
+  it('allows owners before lock', () => {
+    expect(
+      canViewH2HPicksForSession({
+        isOwner: true,
+        lockTime,
+        now: lockTime - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks non-owners before lock', () => {
+    expect(
+      canViewH2HPicksForSession({
+        isOwner: false,
+        lockTime,
+        now: lockTime - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks non-owners when lock time is missing', () => {
+    expect(
+      canViewH2HPicksForSession({
+        isOwner: false,
+        lockTime: undefined,
+        now: lockTime + 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows non-owners after lock', () => {
+    expect(
+      canViewH2HPicksForSession({
+        isOwner: false,
+        lockTime,
+        now: lockTime,
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
getH2HPicksForFeedItem returned predictedWinnerId for any caller before lock. Apply the same owner/lock-time rules as getUserH2HDetailedPicks via a shared canViewH2HPicksForSession helper.