### PR TITLE
chore(backend): incident tooling for mispublished results + scoring docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,14 +139,19 @@ _generated/            # Auto-generated types (do not edit)
 
 ### Scoring (`apps/backend/convex/lib/scoring.ts`)
 
-Users pick exactly 5 drivers per session. Points per pick:
+Users pick exactly 5 drivers per session. Scoring is **order-sensitive** — a pick's
+points depend on its predicted position (slot 1–5) vs the driver's actual finishing
+position. Points per pick, evaluated in order:
 
 - **5 pts** — Exact position match
-- **3 pts** — Off by 1 position
-- **1 pt** — In actual top 5, off by 2+
-- **0 pts** — Not in actual top 5
+- **3 pts** — Off by exactly 1 position (this wins even when the driver finishes
+  just outside the top 5, e.g. predicted P5, finished P6)
+- **1 pt** — Driver finished in actual top 5, off by 2+
+- **0 pts** — Otherwise (driver not in top 5 and not off-by-one)
 
-Max 25 pts/session. Season leaderboard = sum of all session scores.
+Max 25 pts/session. Season leaderboard = sum of all session scores. Scoring is
+identical across every session type (quali / sprint_quali / sprint / race) — there
+is one `scoreTopFive()` and no per-session branching in the point math.
 
 ### Key Business Rules
 

--- a/apps/backend/convex/races.ts
+++ b/apps/backend/convex/races.ts
@@ -1,7 +1,7 @@
 import { v } from 'convex/values';
 
 import type { Doc, Id } from './_generated/dataModel';
-import { mutation, query } from './_generated/server';
+import { internalMutation, mutation, query } from './_generated/server';
 import { getOrCreateViewer, requireAdmin, requireViewer } from './lib/auth';
 import { scheduleSessionLockNotifications } from './inAppNotifications';
 import { getRaceTimeZoneFromSlug } from './lib/raceTimezones';
@@ -300,5 +300,34 @@ export const adminRestoreRace = mutation({
       status: 'upcoming',
       updatedAt: Date.now(),
     });
+  },
+});
+
+/**
+ * CLI/dashboard only — not callable from the public Convex API.
+ * Run via: npx convex run --prod races:emergencySetRaceStatus \
+ *   '{"raceId":"...","status":"upcoming"}'
+ */
+export const emergencySetRaceStatus = internalMutation({
+  args: {
+    raceId: v.id('races'),
+    status: v.union(
+      v.literal('upcoming'),
+      v.literal('locked'),
+      v.literal('finished'),
+      v.literal('cancelled'),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const race = await ctx.db.get(args.raceId);
+    if (!race) {
+      throw new Error('Race not found');
+    }
+    const previous = race.status;
+    await ctx.db.patch(args.raceId, {
+      status: args.status,
+      updatedAt: Date.now(),
+    });
+    return { ok: true, previous, status: args.status };
   },
 });

--- a/apps/backend/convex/results.ts
+++ b/apps/backend/convex/results.ts
@@ -724,6 +724,81 @@ export const emergencyRollbackResults = internalMutation({
   handler: async (ctx, args) => rollbackResultsCore(ctx, args),
 });
 
+/**
+ * CLI/dashboard only — not callable from the public Convex API.
+ * Fixes a result that was published under the wrong session: rolls back the
+ * `fromSession` result (and its scores/H2H/standings/feed) and republishes the
+ * exact same classification under `toSession`. By default it reuses the
+ * classification already entered; pass `classification` to override it.
+ *
+ * Run via:
+ *   npx convex run --prod results:emergencyMoveResultToSession \
+ *     '{"raceId":"...","fromSession":"race","toSession":"quali","restoreRaceStatus":"locked"}'
+ */
+export const emergencyMoveResultToSession = internalMutation({
+  args: {
+    raceId: v.id('races'),
+    fromSession: sessionTypeValidator,
+    toSession: sessionTypeValidator,
+    // Race status to restore when fromSession is 'race' (it was flipped to
+    // 'finished' by the bad publish). Ignored for non-race fromSession.
+    restoreRaceStatus: v.optional(
+      v.union(
+        v.literal('upcoming'),
+        v.literal('locked'),
+        v.literal('finished'),
+      ),
+    ),
+    // Optional override; defaults to the classification already on fromSession.
+    classification: v.optional(v.array(v.id('drivers'))),
+    dnfDriverIds: v.optional(v.array(v.id('drivers'))),
+    suppressNotifications: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    if (args.fromSession === args.toSession) {
+      throw new Error('fromSession and toSession must differ');
+    }
+
+    const existing = await ctx.db
+      .query('results')
+      .withIndex('by_race_session', (q) =>
+        q.eq('raceId', args.raceId).eq('sessionType', args.fromSession),
+      )
+      .unique();
+
+    if (!existing) {
+      throw new Error(`No result found for session "${args.fromSession}"`);
+    }
+
+    // Capture the entered data before the rollback deletes the row.
+    const classification = args.classification ?? existing.classification;
+    const dnfDriverIds = args.dnfDriverIds ?? existing.dnfDriverIds;
+
+    const rollback = await rollbackResultsCore(ctx, {
+      raceId: args.raceId,
+      sessionType: args.fromSession,
+      restoreRaceStatus: args.restoreRaceStatus,
+    });
+
+    const publish = await publishResultsCore(ctx, {
+      raceId: args.raceId,
+      sessionType: args.toSession,
+      classification,
+      dnfDriverIds,
+      suppressNotifications: args.suppressNotifications,
+    });
+
+    return {
+      ok: true,
+      movedFrom: args.fromSession,
+      movedTo: args.toSession,
+      classificationLength: classification.length,
+      rollback,
+      publish,
+    };
+  },
+});
+
 // ============ Top-5 scoring fan-out ============
 
 export const scoreTopFiveForSession = internalMutation({


### PR DESCRIPTION
Add CLI-only internal mutations for recovering from a result published under the wrong session (the Monaco quali-vs-race mixup):

- results.emergencyMoveResultToSession: rolls back a result published under the wrong session and republishes the same classification under the correct one, in one transaction.
- races.emergencySetRaceStatus: restores a race's status (e.g. back to 'upcoming') without needing an authed admin identity, callable via CLI.

Also clarify the scoring docs in CLAUDE.md: off-by-one always scores 3 (even when the driver finishes just outside the top 5), scoring is order-sensitive, and there is a single session-agnostic scoreTopFive().