### PR TITLE
Replace unnecessary em dashes in user-facing copy

### DIFF
--- a/apps/backend/convex/emails/PredictionReminderEmail.tsx
+++ b/apps/backend/convex/emails/PredictionReminderEmail.tsx
@@ -67,7 +67,7 @@ export function PredictionReminderEmail({
         `}</style>
       </Head>
       <Preview>
-        {raceName} predictions lock in {timeUntilLock} — submit your picks!
+        {raceName} predictions lock in {timeUntilLock}. Submit your picks!
       </Preview>
       <Body style={body}>
         <Container style={container}>

--- a/apps/backend/convex/push.ts
+++ b/apps/backend/convex/push.ts
@@ -274,7 +274,7 @@ export const sendPushRemindersForRace = internalMutation({
       await scheduleSendPushBatches(ctx, {
         subscriptions: subs,
         title: `⏰ ${race.name}`,
-        body: `Picks close in 2 hours — you haven't made your predictions yet!`,
+        body: `Picks close in 2 hours. You haven't made your predictions yet!`,
         url,
       });
       return { queued: subs.length };
@@ -307,7 +307,7 @@ export const sendPushRemindersForRace = internalMutation({
       await scheduleSendPushBatches(ctx, {
         subscriptions: subs,
         title: `🏎️ ${race.name}`,
-        body: `Picks open — you have 24 hours to make your predictions`,
+        body: `Picks are open. You have 24 hours to make your predictions`,
         url: `/races/${race.slug}?utm_source=push&utm_medium=push&utm_campaign=prediction_reminder`,
       });
       queued += subs.length;
@@ -320,7 +320,7 @@ export const sendPushRemindersForRace = internalMutation({
       await scheduleSendPushBatches(ctx, {
         subscriptions: subs,
         title: `🔒 ${race.name}`,
-        body: `Your picks are in. Picks lock in 24 hours — edit before then.`,
+        body: `Your picks are in. Picks lock in 24 hours, so edit before then.`,
         url: `/races/${race.slug}?utm_source=push&utm_medium=push&utm_campaign=lock_approaching`,
       });
       queued += subs.length;
@@ -384,7 +384,7 @@ export const sendPushResultsForSession = internalMutation({
     );
 
     const sessionLabel = SESSION_LABELS_FULL[args.sessionType];
-    const title = `🏁 ${race.name} — ${sessionLabel} results`;
+    const title = `🏁 ${race.name}: ${sessionLabel} results`;
     const body = `Session results are in. See how you scored!`;
     const url = `/races/${race.slug}?utm_source=push&utm_medium=push&utm_campaign=results`;
 
@@ -463,7 +463,7 @@ export const sendPushForSessionLocked = internalMutation({
         internal.pushNotifications.sendPushBatch,
         {
           subscriptions: subscriptions.slice(i, i + BATCH_SIZE),
-          title: `🔒 ${race.name} — ${sessionLabel}`,
+          title: `🔒 ${race.name}: ${sessionLabel}`,
           body: "See everyone's picks.",
           url: `/feed?utm_source=push&utm_medium=push&utm_campaign=session_locked`,
         },

--- a/apps/backend/convex/results.ts
+++ b/apps/backend/convex/results.ts
@@ -206,7 +206,7 @@ async function publishResultsCore(
 
   if (amendmentNote && !existing) {
     throw new Error(
-      'Cannot amend a result that has not been published yet — publish it normally first',
+      'Cannot amend a result that has not been published yet. Publish it normally first',
     );
   }
 

--- a/apps/mobile/src/components/home/HomeExplore.tsx
+++ b/apps/mobile/src/components/home/HomeExplore.tsx
@@ -17,7 +17,7 @@ const ITEMS: ReadonlyArray<ExploreItem> = [
   {
     icon: 'trophy-outline',
     title: 'Make your picks',
-    body: 'Top 5 drivers for the next session — every point counts.',
+    body: 'Top 5 drivers for the next session. Every point counts.',
     tab: 'PredictTab',
   },
   {

--- a/apps/mobile/src/components/predict/DraggableTop5.tsx
+++ b/apps/mobile/src/components/predict/DraggableTop5.tsx
@@ -295,7 +295,7 @@ export function DraggableTop5({
           <Text style={styles.poolHeader}>
             {poolFull
               ? 'Tap a pick to remove · long-press a row to reorder'
-              : `${MAX_PICKS - picks.length} remaining — tap to add`}
+              : `${MAX_PICKS - picks.length} remaining. Tap to add`}
           </Text>
           <FlatList
             columnWrapperStyle={styles.poolRow}
@@ -322,7 +322,7 @@ export function DraggableTop5({
             size={14}
           />
           <Text style={styles.lockedNoteText}>
-            Session locked — picks are read-only
+            Session locked. Picks are read-only.
           </Text>
         </View>
       )}

--- a/apps/mobile/src/screens/NotificationsScreen.tsx
+++ b/apps/mobile/src/screens/NotificationsScreen.tsx
@@ -294,12 +294,12 @@ function getNotificationTitle(notification: Notification): string {
   }
   if (notification.type === 'results_published') {
     const points = notification.points ?? 0;
-    return `Results published — ${points} pt${points === 1 ? '' : 's'}`;
+    return `Results published: ${points} pt${points === 1 ? '' : 's'}`;
   }
   if (notification.type === 'results_amended') {
     const points = notification.points;
     return points !== undefined
-      ? `Results amended — now ${points} pt${points === 1 ? '' : 's'}`
+      ? `Results amended: now ${points} pt${points === 1 ? '' : 's'}`
       : 'Results amended';
   }
   return 'Session locked';

--- a/apps/mobile/src/screens/PicksConnectedScreen.tsx
+++ b/apps/mobile/src/screens/PicksConnectedScreen.tsx
@@ -699,7 +699,7 @@ function Top5Editor({
 
       {lockSoon ? (
         <Text style={styles.warnText}>
-          Heads up — locks soon. Save before the session starts.
+          Heads up: locks soon. Save before the session starts.
         </Text>
       ) : null}
 

--- a/apps/mobile/src/screens/auth/SignInScreen.tsx
+++ b/apps/mobile/src/screens/auth/SignInScreen.tsx
@@ -138,7 +138,7 @@ export function SignInScreen() {
         // Clerk has a session on the device that never got activated. Clear
         // it so the next tap starts fresh.
         await clearStuckSession();
-        setError('Cleared a stale session — please try signing in again.');
+        setError('Cleared a stale session. Please try signing in again.');
         return;
       }
       // Log the full error so we can see what's actually going wrong.
@@ -173,7 +173,7 @@ export function SignInScreen() {
     } catch (err) {
       if (isAlreadySignedInError(err)) {
         await clearStuckSession();
-        setError('Cleared a stale session — please try signing in again.');
+        setError('Cleared a stale session. Please try signing in again.');
       } else {
         setError(clerkMessage(err, 'Sign-in failed'));
       }
@@ -197,7 +197,7 @@ export function SignInScreen() {
     } catch (err) {
       if (isAlreadySignedInError(err)) {
         await clearStuckSession();
-        setError('Cleared a stale session — please try signing up again.');
+        setError('Cleared a stale session. Please try signing up again.');
       } else {
         setError(clerkMessage(err, 'Sign-up failed'));
       }
@@ -220,7 +220,7 @@ export function SignInScreen() {
     } catch (err) {
       if (isAlreadySignedInError(err)) {
         await clearStuckSession();
-        setError('Cleared a stale session — please try signing up again.');
+        setError('Cleared a stale session. Please try signing up again.');
       } else {
         setError(clerkMessage(err, 'Invalid code'));
       }

--- a/apps/mobile/src/screens/leagues/LeagueDetailScreen.tsx
+++ b/apps/mobile/src/screens/leagues/LeagueDetailScreen.tsx
@@ -132,7 +132,7 @@ function LeaderboardTab({ leagueId }: { leagueId: ConvexId<'leagues'> }) {
       ItemSeparatorComponent={() => <View style={styles.divider} />}
       ListEmptyComponent={
         <EmptyState
-          body="No scores yet — predictions will appear here after sessions are scored."
+          body="No scores yet. Predictions will appear here after sessions are scored."
           icon="trophy-outline"
           title="No standings yet"
         />

--- a/apps/mobile/src/screens/races/RaceCalendarScreen.tsx
+++ b/apps/mobile/src/screens/races/RaceCalendarScreen.tsx
@@ -74,7 +74,7 @@ export function RaceCalendarScreen({ navigation }: Props) {
           <Text style={styles.emptyText}>
             {tab === 'past'
               ? 'No races have finished yet this season.'
-              : 'No upcoming races — see you next season.'}
+              : 'No upcoming races. See you next season.'}
           </Text>
         }
         refreshControl={

--- a/apps/web/src/components/FeedItem.tsx
+++ b/apps/web/src/components/FeedItem.tsx
@@ -133,7 +133,7 @@ function getScoreComment(
       return 'All five called perfectly.';
     }
     if (exact.length === 4) {
-      return 'Four exact calls — nearly flawless.';
+      return 'Four exact calls. Nearly flawless.';
     }
     if (exact.length === 3) {
       return 'Three spot-on predictions.';

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -77,8 +77,8 @@ function NextRaceQuickLink({ isSignedIn }: { isSignedIn: boolean }) {
       to="/races/$raceSlug"
       params={{ raceSlug: nextRace.slug }}
       className="flex shrink-0 items-center gap-1.5 rounded-full border border-accent/35 bg-accent/10 py-1.5 pr-2.5 pl-2 text-xs font-semibold whitespace-nowrap text-accent transition-colors hover:bg-accent/20 hover:text-accent-hover min-[844px]:hidden min-[900px]:flex"
-      aria-label={`${nextRace.name} — your picks`}
-      title={`${nextRace.name} — your picks`}
+      aria-label={`${nextRace.name}: your picks`}
+      title={`${nextRace.name}: your picks`}
       data-testid="header-next-race-link"
     >
       {countryCode ? (

--- a/apps/web/src/components/OfflineBanner.tsx
+++ b/apps/web/src/components/OfflineBanner.tsx
@@ -61,7 +61,7 @@ export function OfflineBanner() {
             className="flex items-center justify-center gap-2 border-b border-warning/25 bg-warning/10 px-4 py-2 text-sm font-medium text-warning"
           >
             <WifiOff size={14} aria-hidden="true" />
-            <span>No internet connection — data may be outdated</span>
+            <span>No internet connection. Data may be outdated.</span>
           </div>
         </motion.div>
       )}

--- a/apps/web/src/components/RaceScoreCard/CardActions.tsx
+++ b/apps/web/src/components/RaceScoreCard/CardActions.tsx
@@ -72,7 +72,7 @@ export function CardActions({ data, cardState, variant }: CardActionsProps) {
           Sign in to make your prediction
         </p>
         <p className="mb-4 text-sm text-text-muted">
-          Pick your top 5 for each session and call the teammate battles — it's
+          Pick your top 5 for each session and call the teammate battles. It's
           free, and each session is worth up to 25 points.
         </p>
         <SignInButton
@@ -121,7 +121,7 @@ export function CardActions({ data, cardState, variant }: CardActionsProps) {
       <div className="flex items-center justify-center gap-1.5 border-t border-border/60 px-4 py-3">
         <Lock className="h-3.5 w-3.5 text-text-muted/50" />
         <span className="text-sm text-text-muted">
-          Picks submitted — revealed when session locks
+          Picks submitted. Revealed when the session locks.
         </span>
       </div>
     );

--- a/apps/web/src/components/admin/AdminBannerTab.tsx
+++ b/apps/web/src/components/admin/AdminBannerTab.tsx
@@ -86,8 +86,8 @@ export function AdminBannerTab() {
       console.error('Failed to publish announcement:', err);
       setError(
         err instanceof Error && err.message.includes('Auto-hide')
-          ? 'Check the schedule — the auto-hide time must be in the future and after the show-from time.'
-          : 'Failed to publish — try again.',
+          ? 'Check the schedule: the auto-hide time must be in the future and after the show-from time.'
+          : 'Failed to publish. Try again.',
       );
     } finally {
       setIsSaving(false);
@@ -101,7 +101,7 @@ export function AdminBannerTab() {
       await clearAnnouncement({});
     } catch (err) {
       console.error('Failed to clear announcement:', err);
-      setError('Failed to take the banner down — try again.');
+      setError('Failed to take the banner down. Try again.');
     } finally {
       setIsSaving(false);
     }
@@ -119,7 +119,7 @@ export function AdminBannerTab() {
           </span>
         </div>
         <p className="mb-4 text-sm text-slate-400">
-          A dismissible message shown to everyone at the top of the site — e.g.
+          A dismissible message shown to everyone at the top of the site, e.g.
           "Results will be published late while we wait for FIA penalty
           decisions." Publishing again replaces the current message and re-shows
           it to users who dismissed the old one.
@@ -137,7 +137,7 @@ export function AdminBannerTab() {
           onChange={(event) => setMessage(event.target.value)}
           rows={3}
           maxLength={MAX_ANNOUNCEMENT_LENGTH}
-          placeholder="e.g. Heads up — this weekend's results may be published a little later than usual."
+          placeholder="e.g. Heads up: this weekend's results may be published a little later than usual."
           className="w-full rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-slate-400 focus:outline-none"
         />
         <div className="mt-1 text-right text-xs text-slate-500">
@@ -161,7 +161,7 @@ export function AdminBannerTab() {
               className="w-full rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white [color-scheme:dark] focus:border-slate-400 focus:outline-none"
             />
             <p className="mt-1 text-xs text-slate-500">
-              Hold the banner back until then — e.g. when the session was
+              Hold the banner back until then, e.g. when the session was
               expected to finish. Empty shows it immediately.
             </p>
           </div>
@@ -181,8 +181,8 @@ export function AdminBannerTab() {
               className="w-full rounded-lg border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white [color-scheme:dark] focus:border-slate-400 focus:outline-none"
             />
             <p className="mt-1 text-xs text-slate-500">
-              Takes itself down — no need to remember to clear it. Empty keeps
-              it up until you take it down.
+              Takes itself down automatically. No need to remember to clear it.
+              Empty keeps it up until you take it down.
             </p>
           </div>
         </div>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -85,13 +85,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       {
         property: 'og:image:alt',
         content:
-          'Grand Prix Picks — make F1 predictions and climb the 2026 leaderboard.',
+          'Grand Prix Picks: make F1 predictions and climb the 2026 leaderboard.',
       },
       { name: 'twitter:card', content: 'summary_large_image' },
       {
         name: 'twitter:image:alt',
         content:
-          'Grand Prix Picks — make F1 predictions and climb the 2026 leaderboard.',
+          'Grand Prix Picks: make F1 predictions and climb the 2026 leaderboard.',
       },
       { name: 'twitter:site', content: siteConfig.social.x.handle },
     ],

--- a/apps/web/src/routes/admin/races/$raceId/-components/UpdateModeSelector.tsx
+++ b/apps/web/src/routes/admin/races/$raceId/-components/UpdateModeSelector.tsx
@@ -34,8 +34,8 @@ export function UpdateModeSelector({
               Silent correction
             </span>
             <span className="block text-sm text-slate-400">
-              I entered the results wrong. Recalculate scores quietly — players
-              are not notified.
+              I entered the results wrong. Recalculate scores quietly. Players
+              won't be notified.
             </span>
           </span>
         </label>
@@ -70,7 +70,7 @@ export function UpdateModeSelector({
             className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-yellow-500 focus:outline-none"
           />
           <p className="mt-1 text-xs text-slate-500">
-            Shown to players word-for-word — say what changed and why.
+            Shown to players word-for-word. Say what changed and why.
           </p>
         </div>
       )}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -118,7 +118,7 @@ export const Route = createFileRoute('/')({
     pageMeta({
       title: 'Grand Prix Picks - Free F1 Prediction Game for the 2026 Season',
       description:
-        'Pick the top 5 every Grand Prix weekend and compete with friends across the season. Free F1 prediction game — qualifying, sprint, and race sessions plus teammate head-to-heads.',
+        'Pick the top 5 every Grand Prix weekend and compete with friends across the season. Free F1 prediction game with qualifying, sprint, and race sessions plus teammate head-to-heads.',
       path: '/',
     }),
 });
@@ -368,7 +368,7 @@ function HomePage() {
                           Race weekend complete
                         </p>
                         <p className="home-hero-state-copy text-sm text-slate-300">
-                          Results published — check the standings!
+                          Results published. Check the standings!
                         </p>
                         <div className="mt-1 flex gap-2">
                           <Button
@@ -397,7 +397,7 @@ function HomePage() {
                           Race weekend in progress
                         </p>
                         <p className="home-hero-state-copy text-sm text-slate-300">
-                          Sessions underway — results coming soon.
+                          Sessions underway. Results coming soon.
                         </p>
                       </>
                     )}
@@ -622,7 +622,7 @@ function HomePage() {
             <p className="mt-3 text-sm text-text-muted">
               Each session scores up to 25 points (all 5 correct). Your weekend
               total is the sum of quali, sprint (if applicable), and race
-              scores—so sprint weekends can earn you more points.
+              scores, so sprint weekends can earn you more points.
             </p>
             <p className="mt-3 text-sm text-text-muted">
               Head-to-Head scoring is separate: each correct teammate matchup

--- a/apps/web/src/routes/leagues/$slug.tsx
+++ b/apps/web/src/routes/leagues/$slug.tsx
@@ -69,7 +69,7 @@ export const Route = createFileRoute('/leagues/$slug')({
       : 'League Standings & Predictions | Grand Prix Picks';
     const description = league
       ? league.description
-        ? `${league.name} — ${league.description}`
+        ? `${league.name}: ${league.description}`
         : `Compete with other members in ${league.name}. View standings and make your F1 predictions on Grand Prix Picks.`
       : 'View league standings, track member rankings, and compete with friends in this private F1 prediction league.';
     return pageMeta({

--- a/apps/web/src/routes/pricing.tsx
+++ b/apps/web/src/routes/pricing.tsx
@@ -43,7 +43,7 @@ export const Route = createFileRoute('/pricing')({
     pageMeta({
       title: 'Pricing | Grand Prix Picks',
       description:
-        'Season Pass pricing for Grand Prix Picks. One purchase for the full F1 season—unlock unlimited leagues and public leagues.',
+        'Season Pass pricing for Grand Prix Picks. One purchase for the full F1 season unlocks unlimited leagues and public leagues.',
       path: '/pricing',
     }),
 });

--- a/apps/web/src/routes/races/$raceSlug/-components/H2HSection.tsx
+++ b/apps/web/src/routes/races/$raceSlug/-components/H2HSection.tsx
@@ -171,7 +171,7 @@ export function H2HSection({
                   <span className="hidden sm:inline">Edit</span>
                 </Button>
               ) : (
-                <Tooltip content="This session has started — predictions can't be changed">
+                <Tooltip content="This session has started. Predictions can't be changed">
                   <span className="inline-flex" data-testid="h2h-locked-badge">
                     <Badge variant="locked" />
                   </span>
@@ -237,7 +237,7 @@ export function H2HSection({
           suspended={showCloseConfirm}
           title={
             editingSession
-              ? `${SESSION_LABELS[editingSession]} — Head-to-Head`
+              ? `${SESSION_LABELS[editingSession]}: Head-to-Head`
               : 'Head-to-Head Predictions'
           }
           subtitle={

--- a/apps/web/src/routes/races/$raceSlug/-components/RaceEventPage/RaceEventPage.tsx
+++ b/apps/web/src/routes/races/$raceSlug/-components/RaceEventPage/RaceEventPage.tsx
@@ -383,7 +383,7 @@ export function RaceEventPage({
             <div className="flex items-center gap-2">
               {selectedSessionData.isLocked &&
               !selectedSessionData.hasResults ? (
-                <Tooltip content="This session has started — predictions can't be changed">
+                <Tooltip content="This session has started. Predictions can't be changed">
                   <span className="shrink-0" data-testid="top5-locked-badge">
                     <Badge variant="locked" />
                   </span>
@@ -494,7 +494,7 @@ export function RaceEventPage({
         suspended={showTop5CloseConfirm}
         title={
           top5OverlaySession
-            ? `${SESSION_LABELS[top5OverlaySession]} — Top 5`
+            ? `${SESSION_LABELS[top5OverlaySession]}: Top 5`
             : 'Top 5 Predictions'
         }
         subtitle={

--- a/apps/web/src/routes/races/$raceSlug/-components/WeekendRecap/WeekendRecap.tsx
+++ b/apps/web/src/routes/races/$raceSlug/-components/WeekendRecap/WeekendRecap.tsx
@@ -22,7 +22,7 @@ const TIER_CONFIG: Record<
   onboard: {
     emoji: '✅',
     headline: 'On the board',
-    blurb: 'Points banked — onto the next one.',
+    blurb: 'Points banked. Onto the next one.',
   },
   tough: {
     emoji: '🏁',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up em dash usage across user-facing copy in web, mobile, push notifications, emails, and admin UI. Em dashes were replaced with periods, commas, or colons where they read like filler punctuation rather than serving a clear purpose.

## What changed

- **Web**: home hero states, meta descriptions, tooltips, race card copy, feed score comments, offline banner, header labels, weekend recap blurbs, pricing/league SEO text, and admin banner/amendment helper text
- **Mobile**: picks flow, explore cards, calendar empty state, league detail, notifications, and sign-in error messages
- **Backend**: push notification titles/bodies, prediction reminder email preview, and results amendment error message

## What stayed the same

Em dashes used as **empty-state placeholders** (e.g. missing rank/points in tables) were left unchanged. Code comments and developer docs were not touched.

## Testing

- `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1506-b968-77f1-bee4-cf83461b1c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1506-b968-77f1-bee4-cf83461b1c0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

