### PR TITLE
Always show both track and local time for sessions

### DIFF
--- a/apps/web/src/components/SessionEventSummary.tsx
+++ b/apps/web/src/components/SessionEventSummary.tsx
@@ -32,6 +32,7 @@ export function SessionEventSummary({
   now?: number;
 }) {
   const {
+    settings,
     formatDate,
     formatTime,
     formatInTimeZone,
@@ -69,11 +70,14 @@ export function SessionEventSummary({
     startsAt,
     trackTimeZone,
   );
+  const viewerTimeZone =
+    settings.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
   const localDate = formatDate(startsAt);
   const localTime = formatTime(startsAt);
-  // When the viewer's timezone matches the track's offset (e.g. SAST vs CEST
-  // in summer), the two rows would read identically — skip the redundant one.
-  const localMatchesTrack = localDate === trackDate && localTime === trackTime;
+  const localTimeZoneLabel = formatTimeZoneAbbreviation(
+    startsAt,
+    viewerTimeZone,
+  );
 
   return (
     <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
@@ -94,17 +98,22 @@ export function SessionEventSummary({
             ) : null}
           </span>
         </dd>
-        {!localMatchesTrack && (
-          <>
-            <dt className="text-text-muted">Your time</dt>
-            <dd
-              className="min-w-0 font-medium text-text tabular-nums"
-              suppressHydrationWarning
-            >
+        <dt className="text-text-muted">Your time</dt>
+        <dd
+          className="min-w-0 font-medium text-text tabular-nums"
+          suppressHydrationWarning
+        >
+          <span className="inline-flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
+            <span>
               {localDate} · {localTime}
-            </dd>
-          </>
-        )}
+            </span>
+            {localTimeZoneLabel ? (
+              <span className="text-xs font-normal text-text-muted">
+                {localTimeZoneLabel}
+              </span>
+            ) : null}
+          </span>
+        </dd>
       </dl>
       <div className="shrink-0 self-start sm:self-center">
         {isOpen ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When viewing a race session, the UI showed **On track** time with a timezone abbreviation (e.g. CEST) but hid **Your time** whenever the clock matched — even if the labels differed (e.g. CEST vs GMT+2 at the same offset).

This change always renders both rows and adds a timezone abbreviation to **Your time**, matching the **On track** row.

## Context

`SessionEventSummary` previously compared formatted local vs track date/time strings and skipped the "Your time" row when they were identical. That optimization was confusing when offsets matched but abbreviations did not (common for European circuits in summer).

## Test plan

- [ ] Open the next race detail page for a European GP while in a GMT+2 timezone
- [ ] Confirm both **On track** (with CEST or similar) and **Your time** (with your local abbreviation) are visible
- [ ] Confirm races in a different offset still show distinct times on both rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f36ad-165e-73dd-9c7c-33a3fff81cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f36ad-165e-73dd-9c7c-33a3fff81cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

