### PR TITLE
Fix pre-lock pick metadata and private-league membership leaks

### DIFF
--- a/apps/backend/convex/feed.test.ts
+++ b/apps/backend/convex/feed.test.ts
@@ -6,6 +6,7 @@ import {
   getPersonalizedFeedPageData,
   getSessionLockAt,
   isSessionLockedAt,
+  shouldBroadcastLeagueJoin,
 } from './feed';
 
 const MAX_FEED_SIZE = 40;
@@ -437,6 +438,25 @@ describe('getPersonalizedFeedPageData', () => {
         },
       ],
     });
+  });
+});
+
+describe('shouldBroadcastLeagueJoin', () => {
+  it('broadcasts joins for public leagues without a password', () => {
+    expect(shouldBroadcastLeagueJoin({ visibility: 'public' })).toBe(true);
+  });
+
+  it('never broadcasts joins for private leagues', () => {
+    expect(shouldBroadcastLeagueJoin({ visibility: 'private' })).toBe(false);
+    expect(
+      shouldBroadcastLeagueJoin({ visibility: 'private', password: 'hash' }),
+    ).toBe(false);
+  });
+
+  it('never broadcasts joins for password-protected leagues', () => {
+    expect(
+      shouldBroadcastLeagueJoin({ visibility: 'public', password: 'hash' }),
+    ).toBe(false);
   });
 });
 

--- a/apps/backend/convex/feed.ts
+++ b/apps/backend/convex/feed.ts
@@ -281,6 +281,18 @@ export const writeFeedEventsForSession = internalMutation({
   },
 });
 
+/**
+ * A joined_league feed event exposes the league name + joinable slug to the
+ * joining user's followers. Only broadcast membership of fully public leagues —
+ * private or password-protected leagues would be deanonymized otherwise.
+ */
+export function shouldBroadcastLeagueJoin(league: {
+  visibility: 'private' | 'public';
+  password?: string;
+}): boolean {
+  return league.visibility === 'public' && !league.password;
+}
+
 /** Write a joined_league feed event. Called from leagues.ts after a successful join. */
 export const writeJoinedLeagueFeedEvent = internalMutation({
   args: {
@@ -291,6 +303,10 @@ export const writeJoinedLeagueFeedEvent = internalMutation({
     const user = await ctx.db.get(args.userId);
     const league = await ctx.db.get(args.leagueId);
     if (!user || !league) {
+      return;
+    }
+
+    if (!shouldBroadcastLeagueJoin(league)) {
       return;
     }
 
@@ -1346,5 +1362,43 @@ export const deleteFeedEventsForSession = internalMutation({
       }
       await ctx.db.delete(event._id);
     }
+  },
+});
+
+/**
+ * One-off cleanup: remove joined_league feed events (and their revs) that were
+ * written for private / password-protected leagues before those joins stopped
+ * being broadcast. Run once via `convex run feed:purgePrivateLeagueJoinEvents`.
+ */
+export const purgePrivateLeagueJoinEvents = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    let deletedEvents = 0;
+    let deletedRevs = 0;
+
+    for await (const league of ctx.db.query('leagues')) {
+      if (shouldBroadcastLeagueJoin(league)) {
+        continue;
+      }
+
+      for await (const event of ctx.db
+        .query('feedEvents')
+        .withIndex('by_league_created', (q) => q.eq('leagueId', league._id))) {
+        if (event.type !== 'joined_league') {
+          continue;
+        }
+
+        for await (const rev of ctx.db
+          .query('revs')
+          .withIndex('by_event', (q) => q.eq('feedEventId', event._id))) {
+          await ctx.db.delete(rev._id);
+          deletedRevs += 1;
+        }
+        await ctx.db.delete(event._id);
+        deletedEvents += 1;
+      }
+    }
+
+    return { deletedEvents, deletedRevs };
   },
 });

--- a/apps/backend/convex/predictions.ts
+++ b/apps/backend/convex/predictions.ts
@@ -220,11 +220,13 @@ export const getUserPredictionHistory = query({
           const isLocked = lockTime != null && now >= lockTime;
 
           if (!isOwner && !isLocked) {
+            // Visitors before lock only learn that picks exist and are hidden.
+            // Do not leak the exact submission time (participation metadata).
             sessions[sessionType] = {
               picks: [],
               points: null,
               breakdown: null,
-              submittedAt: pred.submittedAt,
+              submittedAt: 0,
               isHidden: true,
             };
           } else {
@@ -246,9 +248,13 @@ export const getUserPredictionHistory = query({
           0,
         );
 
-        const latestSubmission = Math.max(
-          ...weekendPredictions.map((p) => p.submittedAt),
-        );
+        // Only surface submission times for sessions the viewer is allowed to
+        // see (own picks, or locked). Hidden sessions carry submittedAt: 0.
+        const visibleSubmissions = Object.values(sessions)
+          .map((s) => (s && !s.isHidden ? s.submittedAt : 0))
+          .filter((t) => t > 0);
+        const latestSubmission =
+          visibleSubmissions.length > 0 ? Math.max(...visibleSubmissions) : 0;
 
         return {
           raceId,


### PR DESCRIPTION
Resolves two medium-severity findings from the security review.

## Finding 1 — pre-lock submission metadata leak
`getUserPredictionHistory` returned the victim's exact `submittedAt` timestamp to non-owners before a session locked (via the hidden-session objects), and the weekend-level aggregate `submittedAt` was a max across all predictions including still-hidden ones.

- Hidden sessions now return `submittedAt: 0`.
- Weekend aggregate is computed only from sessions the viewer may see (own picks or locked).
- The intentional "Hidden until lock" indicator is preserved — `submittedAt` was never rendered on web or mobile, so this is a zero-cost strip.

## Finding 2 — private-league membership disclosed via feed
Joining a private/password-protected league emitted a `joined_league` feed event (league name + joinable slug) visible to followers.

- Added `shouldBroadcastLeagueJoin` predicate (reused by both the write path and the cleanup) — only fully public, password-less leagues broadcast joins.
- Guard placed inside `writeJoinedLeagueFeedEvent` so it holds regardless of caller.
- Added `purgePrivateLeagueJoinEvents` one-off internal mutation to remove historical events + their revs. **Already run on prod.**

## Testing
- 3 new unit tests for `shouldBroadcastLeagueJoin` (public / private / password-protected).
- typecheck, lint, and backend tests green.

## Deployment note
These fixes are already deployed to prod (`pnpm deploy:backend`) and the historical cleanup has been run. This PR brings `main` in sync with the deployed code.

## Deliberately out of scope
`rev_received` in-app notifications can reference a purged feed event's id (→ 404 on `/feed/{id}`). No index on `feedEventId` alone, so purging them needs a full scan; judged not worth it for how rare a rev on a private-league join is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)