### PR TITLE
Parallelize independent reads in hot feed/H2H/notification queries

### DIFF
--- a/apps/backend/convex/feed.ts
+++ b/apps/backend/convex/feed.ts
@@ -632,13 +632,18 @@ async function buildSessionHeaders(
   const top5ByKey = new Map<string, Array<Id<'drivers'>>>();
   const driverIdsNeeded = new Set<Id<'drivers'>>();
 
-  for (const [key, { raceId, sessionType }] of combos) {
-    const result = await ctx.db
-      .query('results')
-      .withIndex('by_race_session', (q) =>
-        q.eq('raceId', raceId).eq('sessionType', sessionType),
-      )
-      .unique();
+  const comboResults = await Promise.all(
+    [...combos].map(async ([key, { raceId, sessionType }]) => {
+      const result = await ctx.db
+        .query('results')
+        .withIndex('by_race_session', (q) =>
+          q.eq('raceId', raceId).eq('sessionType', sessionType),
+        )
+        .unique();
+      return [key, result] as const;
+    }),
+  );
+  for (const [key, result] of comboResults) {
     if (result) {
       const top5 = result.classification.slice(0, 5);
       top5ByKey.set(key, top5);
@@ -658,10 +663,12 @@ async function buildSessionHeaders(
       nationality?: string;
     }
   >();
-  for (const driverId of driverIdsNeeded) {
-    const driver = await ctx.db.get(driverId);
+  const drivers = await Promise.all(
+    [...driverIdsNeeded].map((driverId) => ctx.db.get(driverId)),
+  );
+  for (const driver of drivers) {
     if (driver) {
-      driverMap.set(String(driverId), {
+      driverMap.set(String(driver._id), {
         code: driver.code,
         displayName: driver.displayName,
         team: driver.team,
@@ -766,10 +773,12 @@ async function enrichScoreEvent(
         nationality?: string;
       }
     >();
-    for (const driverId of driverIds) {
-      const driver = await ctx.db.get(driverId);
+    const drivers = await Promise.all(
+      driverIds.map((driverId) => ctx.db.get(driverId)),
+    );
+    for (const driver of drivers) {
       if (driver) {
-        driverMap.set(String(driverId), {
+        driverMap.set(String(driver._id), {
           code: driver.code,
           team: driver.team,
           displayName: driver.displayName,
@@ -826,18 +835,20 @@ async function enrichScoreEvent(
         nationality?: string;
       }
     >();
-    for (const pick of score.breakdown) {
-      const id = String(pick.driverId);
-      if (!driverMap.has(id)) {
-        const driver = await ctx.db.get(pick.driverId);
-        if (driver) {
-          driverMap.set(id, {
-            code: driver.code,
-            team: driver.team,
-            displayName: driver.displayName,
-            nationality: driver.nationality,
-          });
-        }
+    const breakdownDriverIds = [
+      ...new Set(score.breakdown.map((pick) => pick.driverId)),
+    ];
+    const breakdownDrivers = await Promise.all(
+      breakdownDriverIds.map((driverId) => ctx.db.get(driverId)),
+    );
+    for (const driver of breakdownDrivers) {
+      if (driver) {
+        driverMap.set(String(driver._id), {
+          code: driver.code,
+          team: driver.team,
+          displayName: driver.displayName,
+          nationality: driver.nationality,
+        });
       }
     }
     picks = score.breakdown.map((pick) => {

--- a/apps/backend/convex/h2h.ts
+++ b/apps/backend/convex/h2h.ts
@@ -1,7 +1,7 @@
 import type { SessionType } from '@grandprixpicks/shared/sessions';
 import { v } from 'convex/values';
 
-import type { Id } from './_generated/dataModel';
+import type { Doc, Id } from './_generated/dataModel';
 import { mutation, query } from './_generated/server';
 import { getOrCreateViewer, getViewer, requireViewer } from './lib/auth';
 import { streamRankedLeaderboardRows } from './lib/leaderboard';
@@ -482,10 +482,21 @@ export const getUserH2HPicksByRace = query({
     const now = Date.now();
     const byRace = new Map<Id<'races'>, Record<SessionType, boolean>>();
 
+    // Predictions share a small set of races — fetch each distinct race once,
+    // in parallel, instead of one sequential get per prediction row.
+    const raceById = new Map<Id<'races'>, Doc<'races'> | null>();
+    if (!isOwner) {
+      const distinctRaceIds = [...new Set(predictions.map((p) => p.raceId))];
+      const races = await Promise.all(
+        distinctRaceIds.map((id) => ctx.db.get(id)),
+      );
+      distinctRaceIds.forEach((id, i) => raceById.set(id, races[i]));
+    }
+
     for (const pred of predictions) {
       // Check lock time to determine visibility for non-owners
       if (!isOwner) {
-        const race = await ctx.db.get(pred.raceId);
+        const race = raceById.get(pred.raceId);
         if (race) {
           const lockTimes: Record<SessionType, number | undefined> = {
             quali: race.qualiLockAt,
@@ -581,10 +592,12 @@ export const getUserH2HDetailedPicks = query({
         nationality: string | null;
       }
     >();
-    for (const id of driverIds) {
-      const d = await ctx.db.get(id as Id<'drivers'>);
+    const drivers = await Promise.all(
+      [...driverIds].map((id) => ctx.db.get(id as Id<'drivers'>)),
+    );
+    for (const d of drivers) {
       if (d) {
-        driverCache.set(id, {
+        driverCache.set(d._id, {
           _id: d._id,
           code: d.code,
           displayName: d.displayName,

--- a/apps/backend/convex/inAppNotifications.ts
+++ b/apps/backend/convex/inAppNotifications.ts
@@ -22,17 +22,19 @@ async function loadFollowedActorIds(
 ) {
   const followedIds = new Set<Id<'users'>>();
 
-  for (const actorId of actorIds) {
-    const existing = await ctx.db
-      .query('follows')
-      .withIndex('by_follower_followee', (q) =>
-        q.eq('followerId', viewerId).eq('followeeId', actorId),
-      )
-      .unique();
-    if (existing) {
-      followedIds.add(actorId);
-    }
-  }
+  await Promise.all(
+    [...actorIds].map(async (actorId) => {
+      const existing = await ctx.db
+        .query('follows')
+        .withIndex('by_follower_followee', (q) =>
+          q.eq('followerId', viewerId).eq('followeeId', actorId),
+        )
+        .unique();
+      if (existing) {
+        followedIds.add(actorId);
+      }
+    }),
+  );
 
   return followedIds;
 }


### PR DESCRIPTION
## Summary

I ran a static analyzer ([convex-doctor](https://github.com/fagnersales/convex-doctor)) over `apps/backend/convex` and worked through its findings by hand. The codebase came out very clean — no correctness errors at all, and most of the performance flags land in seed/testing/backfill code where they don't matter. But a handful of flagged sites are sequential awaited reads inside loops on real user-facing query paths, and one of them is a genuine read-amplification problem. This PR fixes only those read-side loops; nothing else.

## What was wrong

Inside a Convex query, each `await ctx.db.get(...)` / `.unique()` in a loop is issued one at a time. When the reads are independent, issuing them with `Promise.all` gets the same data in roughly one round-trip's worth of latency instead of N.

**The standout: `h2h.getUserH2HPicksByRace`** (public profile H2H tab). For a non-owner viewer, the lock-visibility check did:

```ts
for (const pred of predictions) {
  if (!isOwner) {
    const race = await ctx.db.get(pred.raceId); // one sequential get PER PREDICTION ROW
    ...
```

`h2hPredictions` has one row per matchup pick, so a user with a full season of picks has hundreds of rows (~24 races × up to 4 sessions × ~10 matchups) — yet they span only ~24 distinct races. This fetched the *same race documents* over and over, sequentially, on every profile view by another user. Now the distinct races are fetched once, in parallel, into a `Map` before the loop. The lock-gating logic itself is unchanged.

The remaining fixes are the same shape, smaller scale:

- **`h2h.getUserH2HDetailedPicks`** — the ~20 driver lookups for the matchup grid now run via `Promise.all`.
- **`feed.buildSessionHeaders`** — the per-`(race, session)` results lookups and the driver lookups (both run on every feed-page load) now run in parallel.
- **`feed.enrichScoreEvent`** — the per-pick driver lookups (runs per enriched feed event) now run in parallel; the score-breakdown path dedupes driver IDs first, preserving the old `driverMap.has` skip behavior.
- **`inAppNotifications.loadFollowedActorIds`** — the follow-edge existence checks behind the notification bell now run in parallel.

All changes are pure-read reorderings inside queries — no writes, no ordering-sensitive results (everything lands in id-keyed `Map`s/`Set`s), no visibility/gating semantics changed.

## What I deliberately did *not* touch

- **Sequential awaits in mutations** (`submitH2HPredictions`, `results.ts` scoring, feed backfills, `users.ts` cleanup): loops with writes can have read-after-write and upsert-dedupe semantics; blanket parallelization isn't obviously safe there, and mutations aren't latency-critical the way profile/feed queries are.
- **`Date.now()` in queries** (`getNextRace` etc.): flagged as "won't re-run as time passes", which is true, but it's the standard Convex idiom for lock gating and "fixing" it means changing the client API (passing `now` in) — a product decision, not a lint fix.
- **Prefix-redundant indexes** in `schema.ts` (e.g. `by_user` alongside `by_user_race_session`): removing them changes the implicit sort order of existing prefix queries (`_creationTime` vs. the extra index fields), so each removal needs a per-call-site ordering audit. Not worth the risk for the write-overhead saved.
- **`.collect()` / `.filter()` in `seed.ts` / `testing*.ts`**: dev/admin-only code operating on small dev datasets.
- **`findUserByClerkIdentity` in `lib/auth.ts`**: the loop is sequential *by design* — it tries identity candidates in priority order and returns the first hit; usually a single iteration.

## Verification

- `pnpm --filter @grandprixpicks/backend typecheck` — clean
- `pnpm --filter @grandprixpicks/backend lint` + `oxfmt --check` — clean
- Full backend `vitest` suite — **22 files, 101 tests, all passing**, including `h2h.visibility.test.ts`, which covers exactly the owner/non-owner lock-gating path changed in `getUserH2HPicksByRace`
- Re-ran convex-doctor — all seven flagged sites addressed here are gone from the report; no new findings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
